### PR TITLE
start HolderActivity without animation

### DIFF
--- a/rx_activity_result/src/main/java/rx_activity_result/RxActivityResult.java
+++ b/rx_activity_result/src/main/java/rx_activity_result/RxActivityResult.java
@@ -86,7 +86,8 @@ public class RxActivityResult {
 
             activitiesLifecycle.getOLiveActivity().subscribe(new Action1<Activity>() {
                 @Override public void call(Activity activity) {
-                    activity.startActivity(new Intent(activity, HolderActivity.class));
+                    activity.startActivity(new Intent(activity, HolderActivity.class)
+                            .addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION));
                 }
             });
 


### PR DESCRIPTION
It's better to start HolderActivity without animation.
https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NO_ANIMATION