### PR TITLE
Forward Throwable to onError() when ActivityNotFoundException thrown

### DIFF
--- a/app/src/main/java/app/OnPreResultActivity.java
+++ b/app/src/main/java/app/OnPreResultActivity.java
@@ -26,7 +26,7 @@ public class OnPreResultActivity extends AppCompatActivity {
 
         startPreForResult.setOnClickListener(v ->
             RxActivityResult.on(this)
-                .startIntent(new Intent(this, FirstActivity.class), (resultCode, data) ->
+                .startIntent(new Intent(this, FirstActivity.class), (resultCode, requestCode, data) ->
                         Observable.just(Ignore.Get)
                                 .map(_I -> data.putExtra(EXTRA_PRE, "Do whatever you want with the data, but not with the UI")))
                 .subscribe(result -> {

--- a/app/src/main/java/app/SampleActivity.java
+++ b/app/src/main/java/app/SampleActivity.java
@@ -34,7 +34,7 @@ public class SampleActivity extends AppCompatActivity {
                     } else {
                         result.targetUI().printUserCanceled();
                     }
-                });
+                }, Throwable::printStackTrace);
     }
 
     private void showImage(Intent data) {

--- a/rx_activity_result/src/main/java/rx_activity_result2/HolderActivity.java
+++ b/rx_activity_result/src/main/java/rx_activity_result2/HolderActivity.java
@@ -17,6 +17,7 @@
 package rx_activity_result2;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
@@ -52,7 +53,13 @@ public class HolderActivity extends Activity {
             if (requestIntentSender.getOptions() == null) startIntentSender(requestIntentSender);
             else startIntentSenderWithOptions(requestIntentSender);
         } else {
-            startActivityForResult(request.intent(), 0);
+            try {
+                startActivityForResult(request.intent(), 0);
+            } catch (ActivityNotFoundException e) {
+                if (onResult != null) {
+                    onResult.error(e);
+                }
+            }
         }
     }
 

--- a/rx_activity_result/src/main/java/rx_activity_result2/OnResult.java
+++ b/rx_activity_result/src/main/java/rx_activity_result2/OnResult.java
@@ -7,4 +7,5 @@ import java.io.Serializable;
 
 interface OnResult extends Serializable {
     void response(int requestCode, int resultCode, @Nullable Intent data);
+    void error(Throwable throwable);
 }

--- a/rx_activity_result/src/main/java/rx_activity_result2/RxActivityResult.java
+++ b/rx_activity_result/src/main/java/rx_activity_result2/RxActivityResult.java
@@ -117,6 +117,11 @@ public final class RxActivityResult {
                     subject.onNext(new Result<>(activity, requestCode, resultCode, data));
                     subject.onComplete();
                 }
+
+                @Override
+                public void error(Throwable throwable) {
+                    subject.onError(throwable);
+                }
             };
         }
 
@@ -140,6 +145,11 @@ public final class RxActivityResult {
 
                     //If code reaches this point it means some other activity has been stacked as a secondary process.
                     //Do nothing until the current activity be the target activity to get the associated fragment
+                }
+
+                @Override
+                public void error(Throwable throwable) {
+                    subject.onError(throwable);
                 }
             };
         }


### PR DESCRIPTION
I discovered that if you call a method `startActivityForResult()` for `ACTION_IMAGE_CAPTURE` and there is no Camera App installed on device, an `ActivityNotFoundException` is thrown and app crashes. I think that exception should be caught and forwarded to `onError()` RxJava method.