### PR TITLE
Guard against lazy init of child fragment manager

### DIFF
--- a/rx_activity_result/build.gradle
+++ b/rx_activity_result/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.VictorAlbertos'
-version='0.4.1-2.x'
+version='0.4.4-2.x'
 
 android {
     compileSdkVersion 25
@@ -27,4 +27,10 @@ dependencies {
     compile "io.reactivex.rxjava2:rxjava:2.0.5"
 
     testCompile 'junit:junit:4.12'
+}
+
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'RxActivityResult'
+    }
 }

--- a/rx_activity_result/src/main/java/rx_activity_result2/RxActivityResult.java
+++ b/rx_activity_result/src/main/java/rx_activity_result2/RxActivityResult.java
@@ -161,7 +161,7 @@ public final class RxActivityResult {
             for (Fragment fragment : fragments) {
                 if (fragment != null && fragment.isVisible() && fragment.getClass() == clazz) {
                     return fragment;
-                } else if (fragment != null && fragment.getChildFragmentManager() != null) {
+                } else if (fragment != null && fragment.isAdded() && fragment.getChildFragmentManager() != null) {
                     List<Fragment> childFragments = fragment.getChildFragmentManager().getFragments();
                     Fragment candidate = getTargetFragment(childFragments);
                     if (candidate != null) return candidate;


### PR DESCRIPTION
Fixes https://github.com/VictorAlbertos/RxActivityResult/issues/44

I'm not sure if there are any implications of adding this isAdded() check or if you could expect to legitimately operate on a fragment which has not been added to the activity.